### PR TITLE
Forgot to cast

### DIFF
--- a/minefield.c
+++ b/minefield.c
@@ -16,7 +16,7 @@ Tile *get_tile_ptr(Minefield *minefield, int col, int row) {
 
 void init_minefield(Minefield *minefield, int cols, int rows) {
     /* Allocate memory for minefield */
-    minefield = malloc(sizeof(Minefield));
+    minefield = (Minefield *)malloc(sizeof(Minefield));
     
     printf("Setting cols to %i\n", cols);
     minefield->cols = cols;


### PR DESCRIPTION
Forgot to cast the pointer returned by malloc to the proper pointer type.